### PR TITLE
商品詳細機能実装

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -10,6 +10,11 @@ class ProductsController < ApplicationController
 
   def new
     @product = Product.new
+    if user_signed_in?
+       @product = Product.new
+    else
+       redirect_to user_session_path(@product.id)
+    end
   end
 
   def create
@@ -20,6 +25,10 @@ class ProductsController < ApplicationController
       render :new
     end
   end
+
+  def show
+    @product = Product.find(params[:id])
+  end 
 
   # def edit
   #   @product = Product.find(params[:id])
@@ -34,7 +43,7 @@ class ProductsController < ApplicationController
 
   private
   def product_params
-    params.require(:product).permit(:name, :image, :description, :category_id, :condition_id, :shipping_cost_id, :prefecture_id, :shipping_days_id, :price).merge(user_id: current_user.id)
+    params.require(:product).permit(:name, :image, :description, :category_id, :condition_id, :shipping_cost_id, :prefecture_id, :shipping_day_id, :price).merge(user_id: current_user.id)
   end
 
   # def ensure_current_user

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -10,11 +10,6 @@ class ProductsController < ApplicationController
 
   def new
     @product = Product.new
-    if user_signed_in?
-       @product = Product.new
-    else
-       redirect_to user_session_path(@product.id)
-    end
   end
 
   def create

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -14,7 +14,7 @@ extend ActiveHash::Associations::ActiveRecordExtensions
   validates :description,             presence: true
   validates :condition_id,                            numericality: { other_than: 1 , message: "can't be blank"}
   validates :shipping_cost_id,                        numericality: { other_than: 1 , message: "can't be blank"}
-  validates :shipping_days_id,                        numericality: { other_than: 1 , message: "can't be blank"}
+  validates :shipping_day_id,                        numericality: { other_than: 1 , message: "can't be blank"}
   validates :prefecture_id,                           numericality: { other_than: 1 , message: "can't be blank"}
   validates :category_id,                             numericality: { other_than: 1 , message: "can't be blank"}
   validates :image,                   presence: true

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -129,8 +129,7 @@
       <% if @products.present? %>
       <% @products.each do |product| %>
       <li class='list'>
-      <%#= link_to products_path(product.id) do %>
-        <%= link_to '#' do %>
+      <%= link_to product_path(product.id) do %>
         <div class='item-img-content'>
           <%= image_tag product.image, class: "item-img" %>
 

--- a/app/views/products/new.html.erb
+++ b/app/views/products/new.html.erb
@@ -79,7 +79,7 @@
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:shipping_days_id, ShippingDay.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:shipping_day_id, ShippingDay.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -4,39 +4,39 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @product.name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @product.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <% if product.purchase.present?  %>
+      <%# <% if product.purchase.present?  %> 
          <div class="sold-out">
           <span>Sold Out!!</span>
          </div>
-      <% end %>
+      <%# <% end %>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= @product.price%>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @product.shipping_cost.name %>
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <% if user_signed_in? %>
+      <% if current_user.id == @product.user_id %>
+        <%= link_to "商品の編集", product_path(@product), method: :get, class: "item-red-btn" %>
+        <p class="or-text">or</p>
+        <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
 
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
+        <% else %>
+        <%= link_to "購入画面に進む", product_path(@product.id) ,class:"item-red-btn"%>
+      <% end %>
+    <% end %>
 
 
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
       <span><%= "商品説明" %></span>
@@ -45,27 +45,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @product.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @product.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @product.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @product.shipping_cost.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @product.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @product.shipping_day.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -104,9 +104,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
   <a href="#" class="another-item"><%= @product.category.name %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -39,7 +39,7 @@
 
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @product.description %></span>
     </div>
     <table class="detail-table">
       <tbody>
@@ -105,7 +105,7 @@
     </a>
   </div>
   <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class="another-item"><%= @product.category.name %>をもっと見る</a>
   <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "products#index"
-  resources :products, only: [:index, :new, :create]
+  resources :products, only: [:index, :new, :create, :show]
+  
 end

--- a/db/migrate/20211111143156_create_products.rb
+++ b/db/migrate/20211111143156_create_products.rb
@@ -6,7 +6,7 @@ class CreateProducts < ActiveRecord::Migration[6.0]
       t.text    :description,      null: false
       t.integer :condition_id,     null: false
       t.integer :shipping_cost_id, null: false
-      t.integer :shipping_days_id, null: false
+      t.integer :shipping_day_id, null: false
       t.integer :prefecture_id,    null: false
       t.integer :category_id,      null: false
       t.references :user,          null: false, foreign_key: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -79,7 +79,7 @@ ActiveRecord::Schema.define(version: 2021_11_12_085945) do
     t.text "description", null: false
     t.integer "condition_id", null: false
     t.integer "shipping_cost_id", null: false
-    t.integer "shipping_days_id", null: false
+    t.integer "shipping_day_id", null: false
     t.integer "prefecture_id", null: false
     t.integer "category_id", null: false
     t.bigint "user_id", null: false

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     description       {"aaa"}
     condition_id      {2}
     shipping_cost_id  {2}
-    shipping_days_id  {2}
+    shipping_day_id  {2}
     prefecture_id     {2}
     category_id       {2}
 

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -73,8 +73,8 @@ RSpec.describe Product, type: :model do
         expect(@product.errors.full_messages).to include("Shipping cost can't be blank")
       end
 
-      it 'shipping_days_idが１では出品できない' do
-        @product.shipping_days_id = '1'
+      it 'shipping_day_idが１では出品できない' do
+        @product.shipping_day_id = '1'
         @product.valid?
         expect(@product.errors.full_messages).to include("Shipping days can't be blank")
       end


### PR DESCRIPTION
What
商品詳細表示機能の実装

Why
商品詳細を表示させるため

ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画
gyazo GIF:https://gyazo.com/d8f21880ed2abca7ae650677e8bbbf9e

ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画
gyazo GIF:https://gyazo.com/f971c026bcc5f477490b667cc8c6ff13

ログイン状態で、売却済み商品の商品詳細ページへ遷移した動画（現段階で商品購入機能の実装が済んでいる場合）
gyazo GIF:なし

ログアウト状態で、商品詳細ページへ遷移した動画
gyazo GIF:https://gyazo.com/e57334759883a58d181ff4e1521960d0